### PR TITLE
Potential Fixes to various issues, including readMap implementation, ActionRequest Depreciation and method overrides

### DIFF
--- a/src/main/java/querqy/elasticsearch/query/Rewriter.java
+++ b/src/main/java/querqy/elasticsearch/query/Rewriter.java
@@ -25,7 +25,7 @@ public class Rewriter implements NamedWriteable, ToXContent {
         name = in.readString();
         final boolean hasParams = in.readBoolean();
         if (hasParams) {
-            params = in.readMap();
+            params = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
         }
     }
 

--- a/src/main/java/querqy/elasticsearch/rewriterstore/DeleteRewriterAction.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/DeleteRewriterAction.java
@@ -11,7 +11,7 @@ public class DeleteRewriterAction extends ActionType<DeleteRewriterResponse> {
      * @param name The name of the action, must be unique across actions.
      */
     protected DeleteRewriterAction(final String name) {
-        super(name, DeleteRewriterResponse::new);
+        super(name);
     }
 
 }

--- a/src/main/java/querqy/elasticsearch/rewriterstore/NodesClearRewriterCacheAction.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/NodesClearRewriterCacheAction.java
@@ -12,7 +12,7 @@ public class NodesClearRewriterCacheAction extends ActionType<NodesClearRewriter
 
 
     protected NodesClearRewriterCacheAction(final String name) {
-        super(name, NodesClearRewriterCacheResponse::new);
+        super(name);
     }
 
 }

--- a/src/main/java/querqy/elasticsearch/rewriterstore/NodesReloadRewriterAction.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/NodesReloadRewriterAction.java
@@ -9,7 +9,7 @@ public class NodesReloadRewriterAction extends ActionType<NodesReloadRewriterRes
 
 
     protected NodesReloadRewriterAction(final String name) {
-        super(name, NodesReloadRewriterResponse::new);
+        super(name);
     }
 
 }

--- a/src/main/java/querqy/elasticsearch/rewriterstore/PutRewriterAction.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/PutRewriterAction.java
@@ -11,7 +11,7 @@ public class PutRewriterAction extends ActionType<PutRewriterResponse> {
      * @param name The name of the action, must be unique across actions.
      */
     protected PutRewriterAction(final String name) {
-        super(name, PutRewriterResponse::new);
+        super(name);
     }
 
 

--- a/src/main/java/querqy/elasticsearch/rewriterstore/PutRewriterRequest.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/PutRewriterRequest.java
@@ -24,7 +24,7 @@ public class PutRewriterRequest extends ActionRequest {
     public PutRewriterRequest(final StreamInput in) throws IOException {
         super(in);
         rewriterId = in.readString();
-        content = in.readMap();
+        content = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
     }
 
     public PutRewriterRequest(final String rewriterId, final Map<String, Object> content) {

--- a/src/main/java/querqy/elasticsearch/rewriterstore/TransportNodesClearRewriterCacheAction.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/TransportNodesClearRewriterCacheAction.java
@@ -31,10 +31,14 @@ public class TransportNodesClearRewriterCacheAction extends TransportNodesAction
                                               final Client client,
                                               final RewriterShardContexts rewriterShardContexts) {
 
-            super(NodesClearRewriterCacheAction.NAME, threadPool, clusterService, transportService, actionFilters,
-                    NodesClearRewriterCacheRequest::new, NodesClearRewriterCacheRequest.NodeRequest::new,
-                    threadPool.executor(ThreadPool.Names.MANAGEMENT));
-            this.rewriterShardContexts = rewriterShardContexts;
+		super(
+			NodesClearRewriterCacheAction.NAME,
+			clusterService,
+			transportService,
+			actionFilters,
+			NodesClearRewriterCacheRequest.NodeRequest::new,
+			threadPool.executor(ThreadPool.Names.MANAGEMENT));
+		this.rewriterShardContexts = rewriterShardContexts;
     }
 
 

--- a/src/main/java/querqy/elasticsearch/rewriterstore/TransportNodesReloadRewriterAction.java
+++ b/src/main/java/querqy/elasticsearch/rewriterstore/TransportNodesReloadRewriterAction.java
@@ -32,12 +32,16 @@ public class TransportNodesReloadRewriterAction extends TransportNodesAction<Nod
                                               final Client client,
                                               final RewriterShardContexts rewriterShardContexts) {
 
-        super(NodesReloadRewriterAction.NAME, threadPool, clusterService, transportService, actionFilters,
-                NodesReloadRewriterRequest::new, NodesReloadRewriterRequest.NodeRequest::new,
-                threadPool.executor(ThreadPool.Names.MANAGEMENT));
-        this.rewriterShardContexts = rewriterShardContexts;
-        this.client = client;
-        this.indexServices = indexServices;
+		super(
+			NodesReloadRewriterAction.NAME, 
+			clusterService, 
+			transportService,
+			actionFilters,
+			NodesReloadRewriterRequest.NodeRequest::new,
+			threadPool.executor(ThreadPool.Names.MANAGEMENT));
+		this.rewriterShardContexts = rewriterShardContexts;
+		this.client = client;
+		this.indexServices = indexServices;
     }
 
     @Override

--- a/src/test/java/querqy/elasticsearch/query/QuerqyQueryBuilderTest.java
+++ b/src/test/java/querqy/elasticsearch/query/QuerqyQueryBuilderTest.java
@@ -29,6 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 import querqy.elasticsearch.QuerqyPlugin;
 import querqy.elasticsearch.QuerqyProcessor;
+//import static querqy.elasticsearch.query.AbstractLuceneQueryTest.bq;
+//import static querqy.elasticsearch.query.AbstractLuceneQueryTest.dtq;
+
 import querqy.lucene.rewrite.DependentTermQueryBuilder;
 import querqy.lucene.rewrite.DocumentFrequencyCorrection;
 import querqy.lucene.rewrite.IndependentFieldBoost;

--- a/src/test/java/querqy/elasticsearch/rewriterstore/DeleteRewriterResponseTest.java
+++ b/src/test/java/querqy/elasticsearch/rewriterstore/DeleteRewriterResponseTest.java
@@ -56,7 +56,7 @@ public class DeleteRewriterResponseTest {
 
         final DeleteResponse deleteResponse1 = new DeleteResponse(new ShardId("idx1", "shard1", 1), "id1",
                 11, 2L, 8L, true);
-        deleteResponse1.setShardInfo(new ReplicationResponse.ShardInfo(2, 1));
+        deleteResponse1.setShardInfo(ReplicationResponse.ShardInfo.of(2, 1));
 
         final NodesClearRewriterCacheResponse clearRewriterCacheResponse1 = new NodesClearRewriterCacheResponse
                 (new ClusterName("cluster27"),

--- a/src/test/java/querqy/elasticsearch/rewriterstore/PutRewriterResponseTest.java
+++ b/src/test/java/querqy/elasticsearch/rewriterstore/PutRewriterResponseTest.java
@@ -90,7 +90,7 @@ public class PutRewriterResponseTest {
         final IndexResponse indexResponse = new IndexResponse(new ShardId("idx1", "shard1", 1), "id1", 11, 2L, 8L,
                 true);
 
-        indexResponse.setShardInfo(new ReplicationResponse.ShardInfo(4, 4));
+        indexResponse.setShardInfo(ReplicationResponse.ShardInfo.of(4, 4));
 
         final DiscoveryNode node1 = new DiscoveryNode("name1", "d1", new TransportAddress(META_ADDRESS, 0),
                 Collections.emptyMap(), Collections.emptySet(), VersionInformation.CURRENT);


### PR DESCRIPTION
I am going to premise this with this is the absolute first time I have ever messed (and I stress messed) with java. I likely do not have the correct or full resources to fully build, run or interpret the output or tests. Many of which failed because something or another could not be initialized (see error from test build below). 

I am hoping this just maybe somehow makes it easier to get this back up to date with elasticSearch 8.14.2 or even 8.15, though I just forked the 8.14.2 branch from dependabot

This will likely need edits by maintainers and that was left checked, but I am glad to do anything you can guide me to do.

I am proposing potential fixes to various issues, including readMap implementation, ActionRequest Depreciation and method overrides

Error output from tests:
```
LuceneQueryBuildingIntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESSingleNodeTestCase
QuerqyMappingsUpdate1To3IntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESSingleNodeTestCase
QuerqyMappingsUpdate2To3IntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESSingleNodeTestCase
RewriterIntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESSingleNodeTestCase
RewriterShardContextsTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESIntegTestCase
RewriterStoreIntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESIntegTestCase
InfoLoggingIntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESSingleNodeTestCase
InfoLoggingMultiShardIntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESTestCase
QuerqyQueryBuilderTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESTestCase
QueryBuildingIntegrationTest » NoClassDefFound Could not initialize class org.elasticsearch.test.ESSingleNodeTestCase
RewriterTest.testStreamSerializationWithParams:34 » EOF tried to read: 99 bytes but only 38 remaining
NumberUnitRewriterFactoryTest>ESTestCase.<clinit>:308 » Runtime unable to install test security manager
ReplaceRewriterIntegrationTest » NoClassDefFound Could not initialize class querqy.elasticsearch.rewriter.AbstractRewriterIntegrationTest
SimpleCommonRulesRewriterFactoryTest » NoClassDefFound Could not initialize class querqy.elasticsearch.rewriter.AbstractRewriterIntegrationTest
PutRewriterRequestTest.testStreamSerialization:80 » IO Can't read unknown type [99]
Tests run: 91, Failures: 0, Errors: 15, Skipped: 0
```