### PR TITLE
Constrain loadable rewriters and parser factories via SPI

### DIFF
--- a/src/main/java/querqy/elasticsearch/ConfigUtils.java
+++ b/src/main/java/querqy/elasticsearch/ConfigUtils.java
@@ -2,13 +2,53 @@ package querqy.elasticsearch;
 
 import querqy.trie.TrieMap;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public interface ConfigUtils {
 
+    Map<Class<?>, Set<String>> ALLOWED_INSTANCES_CACHE = new ConcurrentHashMap<>();
+
+    static <V> Set<String> loadAllowedInstances(final Class<V> type) {
+        return ALLOWED_INSTANCES_CACHE.computeIfAbsent(type, typeClass -> {
+            final String spiFile = "META-INF/services/" + typeClass.getName();
+            final ClassLoader cl = ConfigUtils.class.getClassLoader();
+            final Set<String> allowed = new HashSet<>();
+            try {
+                final Enumeration<URL> resources = cl.getResources(spiFile);
+                while (resources.hasMoreElements()) {
+                    try (BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(resources.nextElement().openStream(), StandardCharsets.UTF_8))) {
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            final int commentIdx = line.indexOf('#');
+                            if (commentIdx >= 0) {
+                                line = line.substring(0, commentIdx);
+                            }
+                            line = line.trim();
+                            if (!line.isEmpty()) {
+                                Class.forName(line, false, cl).asSubclass(typeClass);
+                                allowed.add(line);
+                            }
+                        }
+                    }
+                }
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed to load service providers for " + typeClass.getName(), e);
+            }
+            return Collections.unmodifiableSet(allowed);
+        });
+    }
 
     static String getStringArg(final Map<String, Object> config, final String name, final String defaultValue) {
         final String value = (String) config.get(name);
@@ -41,9 +81,9 @@ public interface ConfigUtils {
         return result;
     }
 
+    @SuppressWarnings("unchecked")
     static <V> V getInstanceFromArg(final Map<String, Object> config, final String name, final V defaultValue,
-                                    final Class<V> expectedType) {
-
+                                    final Class<V> allowedType) {
 
         final String classField = (String) config.get(name);
         if (classField == null) {
@@ -55,12 +95,14 @@ public interface ConfigUtils {
             return defaultValue;
         }
 
+        if (!loadAllowedInstances(allowedType).contains(className)) {
+            throw new IllegalArgumentException(
+                    "Class is not a registered " + allowedType.getSimpleName() +
+                    " service provider: " + className);
+        }
+
         try {
-            Class<V> clazz = (Class<V>) Class.forName(className);
-            if (!expectedType.isAssignableFrom(clazz)) {
-                throw new IllegalArgumentException(className + " not compatible with " + expectedType.getName());
-            }
-            return clazz.getDeclaredConstructor().newInstance();
+            return (V) Class.forName(className).getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/querqy/elasticsearch/ESRewriterFactory.java
+++ b/src/main/java/querqy/elasticsearch/ESRewriterFactory.java
@@ -5,11 +5,57 @@ import org.elasticsearch.index.shard.IndexShard;
 import querqy.elasticsearch.rewriterstore.LoadRewriterConfig;
 import querqy.rewrite.RewriterFactory;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public abstract class ESRewriterFactory {
+
+    private static final Set<String> ALLOWED_CLASSES = loadAllowedClasses();
+
+    private static Set<String> loadAllowedClasses() {
+        final String spiFile = "META-INF/services/" + ESRewriterFactory.class.getName();
+        final ClassLoader cl = ESRewriterFactory.class.getClassLoader();
+        final Set<String> allowed = new HashSet<>();
+        try {
+            final Enumeration<URL> resources = cl.getResources(spiFile);
+            while (resources.hasMoreElements()) {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(resources.nextElement().openStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        final int commentIdx = line.indexOf('#');
+                        if (commentIdx >= 0) {
+                            line = line.substring(0, commentIdx);
+                        }
+                        line = line.trim();
+                        if (!line.isEmpty()) {
+                            Class.forName(line, false, cl).asSubclass(ESRewriterFactory.class);
+                            allowed.add(line);
+                        }
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            throw new RuntimeException("Failed to load ESRewriterFactory service providers", e);
+        }
+        return Collections.unmodifiableSet(allowed);
+    }
+
+    private static void checkClassAllowed(final String className) {
+        if (!ALLOWED_CLASSES.contains(className)) {
+            throw new IllegalArgumentException(
+                    "Class is not a registered ESRewriterFactory service provider: " + className);
+        }
+    }
 
     protected final String rewriterId;
 
@@ -41,6 +87,8 @@ public abstract class ESRewriterFactory {
                     .getConfigMapping().getRewriterClassNameProperty());
         }
 
+        checkClassAllowed(className);
+
         final ESRewriterFactory factory = builder().rewriterId(instanceDescription.getRewriterId())
                 .className(className).loadFactory();
 
@@ -62,6 +110,8 @@ public abstract class ESRewriterFactory {
         if (className.isEmpty()) {
             throw new IllegalArgumentException("Class name expected in property: " + argName);
         }
+
+        checkClassAllowed(className);
 
         return builder()
                 .rewriterId(rewriterId)

--- a/src/main/resources/META-INF/services/querqy.elasticsearch.ESRewriterFactory
+++ b/src/main/resources/META-INF/services/querqy.elasticsearch.ESRewriterFactory
@@ -1,0 +1,5 @@
+querqy.elasticsearch.rewriter.SimpleCommonRulesRewriterFactory
+querqy.elasticsearch.rewriter.RegexReplaceRewriterFactory
+querqy.elasticsearch.rewriter.ReplaceRewriterFactory
+querqy.elasticsearch.rewriter.NumberUnitRewriterFactory
+querqy.elasticsearch.rewriter.WordBreakCompoundRewriterFactory

--- a/src/main/resources/META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory
+++ b/src/main/resources/META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory
@@ -1,0 +1,2 @@
+querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory
+querqy.rewrite.commonrules.FieldAwareWhiteSpaceQuerqyParserFactory

--- a/src/test/resources/META-INF/services/querqy.elasticsearch.ESRewriterFactory
+++ b/src/test/resources/META-INF/services/querqy.elasticsearch.ESRewriterFactory
@@ -1,0 +1,1 @@
+querqy.elasticsearch.DummyESRewriterFactory


### PR DESCRIPTION
ESRewriterFactory implementations and QuerqyParserFactory implementations must now be registered in their respective META-INF/services files to be loadable by the plugin.